### PR TITLE
Update chat API context handling

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -15,15 +15,15 @@ interface ChatMessage {
 
 export async function POST(request: Request) {
   try {
-    const { messages } = await request.json();
+    const { messages, storedContext: bodyContext, teamTerms: bodyTeamTerms } = await request.json();
 
     if (!Array.isArray(messages)) {
       return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
     }
 
-    // Get user's context from localStorage
-    const storedContext = localStorage.getItem("personalContext");
-    const teamTerms = JSON.parse(localStorage.getItem("teamTerms") || "{}");
+    // Use context provided in the request body
+    const storedContext = typeof bodyContext === 'string' ? bodyContext : '';
+    const teamTerms = typeof bodyTeamTerms === 'object' && bodyTeamTerms !== null ? bodyTeamTerms : {};
 
     // Format team terms for the prompt
     const formattedTeamTerms = Object.entries(teamTerms)


### PR DESCRIPTION
## Summary
- read `storedContext` and `teamTerms` from the request body
- construct the prompt using these values

## Testing
- `npx next lint` *(fails: connect EHOSTUNREACH)*