### PR TITLE
Add vitest test framework and helper tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@auth/core": "^0.34.2",
@@ -41,6 +42,7 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/components/progress-notification/helpers.test.ts
+++ b/src/components/progress-notification/helpers.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { convertApiResponseToDocuments, updateDocumentStatus } from './helpers'
+
+// Sample data for tests
+const apiResponse = {
+  documents: [
+    { id: '1', name: 'file1' },
+    { id: '2', name: 'file2' }
+  ],
+  totalDocuments: 2
+}
+
+const documents = [
+  { id: '1', name: 'file1', synced: false },
+  { id: '2', name: 'file2', synced: false }
+]
+
+describe('convertApiResponseToDocuments', () => {
+  it('converts API response to document array', () => {
+    const result = convertApiResponseToDocuments(apiResponse)
+    expect(result).toEqual(documents)
+  })
+})
+
+describe('updateDocumentStatus', () => {
+  it('marks the correct document as synced', () => {
+    const syncResponse = { message: 'ok', documentName: 'file2' }
+    const updated = updateDocumentStatus(documents, syncResponse)
+    expect(updated).toEqual([
+      { id: '1', name: 'file1', synced: false },
+      { id: '2', name: 'file2', synced: true }
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- add vitest test script and dependency
- add unit tests for `convertApiResponseToDocuments` and `updateDocumentStatus`

## Testing
- `npm test` *(fails: vitest not found)*