### PR TITLE
Add setup and env docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,31 @@ bun dev
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+
+## Setup
+
+Install dependencies first so that linting and TypeScript checks work correctly:
+
+```bash
+npm install
+```
+
+Then you can run
+
+```bash
+npm run lint
+npx tsc --noEmit
+```
+
+## Environment Variables
+
+Local development requires a `.env.local` file containing values for:
+
+- `OPENAI_API_KEY`
+- `OPENAI_ORGANIZATION`
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `GOOGLE_REDIRECT_URI`
+- `PINECONE_API_KEY`
+
+Ask the maintainer to provide these values.


### PR DESCRIPTION
## Summary
- document need to run `npm install` before linting or TypeScript checks
- describe environment variables needed for local dev

## Testing
- `npm install` *(fails: connect EHOSTUNREACH)*
- `npm run lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: missing type declarations)*