### PR TITLE
Add resync route and mock-based tests

### DIFF
--- a/src/app/api/__tests__/resync.test.ts
+++ b/src/app/api/__tests__/resync.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { POST } from '../resync/route'
+
+vi.mock('@/lib/auth', () => ({
+  getAuthServerSession: vi.fn().mockResolvedValue({ user: { name: 'Test User' } })
+}))
+
+const list = vi.fn()
+const deleteMany = vi.fn()
+const upsert = vi.fn()
+const namespace = vi.fn(() => ({ list, deleteMany, upsert }))
+vi.mock('@/lib/pinecone', () => ({
+  getUserIndex: vi.fn(() => ({ namespace }))
+}))
+
+function createRequest(body: any) {
+  return { json: async () => body } as unknown as Request
+}
+
+describe('resync route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('lists vectors, deletes them and upserts new ones', async () => {
+    list.mockResolvedValue({ vectors: [{ id: 'abc1' }] })
+    deleteMany.mockResolvedValue(undefined)
+    upsert.mockResolvedValue(undefined)
+
+    const req = createRequest({ prefix: 'abc', vectors: [{ id: 'abc1', values: [] }] })
+    const res = await POST(req)
+
+    expect(list).toHaveBeenCalledWith({ prefix: 'abc' })
+    expect(deleteMany).toHaveBeenCalledWith(['abc1'])
+    expect(upsert).toHaveBeenCalledWith([{ id: 'abc1', values: [] }])
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 500 when deletion fails', async () => {
+    list.mockResolvedValue({ vectors: [{ id: 'fail1' }] })
+    deleteMany.mockRejectedValue(new Error('failed'))
+
+    const req = createRequest({ prefix: 'fail', vectors: [] })
+    const res = await POST(req)
+
+    expect(res.status).toBe(500)
+  })
+})
+

--- a/src/app/api/resync/route.ts
+++ b/src/app/api/resync/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import { getAuthServerSession } from '@/lib/auth'
+import { getUserIndex } from '@/lib/pinecone'
+
+export async function POST(request: Request) {
+  try {
+    const authSession = await getAuthServerSession()
+    if (!authSession?.user?.name) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { prefix, vectors } = await request.json() as { prefix: string; vectors: any[] }
+
+    const formattedUsername = authSession.user.name
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '')
+
+    const index = getUserIndex(`${formattedUsername}`)
+    const namespace = index.namespace('ns1')
+
+    const listed = await namespace.list({ prefix })
+    const ids = listed.vectors.map((v: any) => v.id)
+    if (ids.length) {
+      await namespace.deleteMany(ids)
+    }
+
+    await namespace.upsert(vectors)
+    return NextResponse.json({ message: 'Resync completed' })
+  } catch (error) {
+    console.error('Error during resync:', error)
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add API route for resyncing Pinecone vectors
- test resync route with mocked Pinecone client

## Testing
- `npm test` *(fails: vitest not found)*