### PR TITLE
Add skeleton for My Work dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "openai": "^4.97.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.2.0"
+    "tailwind-merge": "^3.2.0",
+    "date-fns": "^3.6.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/my-work/create-task/route.ts
+++ b/src/app/api/my-work/create-task/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import path from 'path'
+import fs from 'fs/promises'
+import { nanoid } from 'nanoid'
+import { Task } from '@/types/my-work'
+
+export async function POST(request: Request) {
+  const { prdId, title } = await request.json()
+  const dataPath = path.join(process.cwd(), 'src/data/myWork.json')
+  const data = JSON.parse(await fs.readFile(dataPath, 'utf8'))
+  const tasks: Task[] = data.prds_tasks || []
+  const newTask: Task = {
+    id: nanoid(),
+    prd_id: prdId,
+    title,
+    is_done: false,
+    sort_order: tasks.length + 1
+  }
+  tasks.push(newTask)
+  data.prds_tasks = tasks
+  await fs.writeFile(dataPath, JSON.stringify(data, null, 2))
+  return NextResponse.json({ task: newTask })
+}

--- a/src/app/api/my-work/list/route.ts
+++ b/src/app/api/my-work/list/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server'
+import path from 'path'
+import fs from 'fs/promises'
+import { Prd } from '@/types/my-work'
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const page = parseInt(url.searchParams.get('page') || '1', 10)
+  const pageSize = parseInt(url.searchParams.get('pageSize') || '10', 10)
+
+  const dataPath = path.join(process.cwd(), 'src/data/myWork.json')
+  const data = JSON.parse(await fs.readFile(dataPath, 'utf8'))
+  const prds: Prd[] = data.prds || []
+  const prds_reviewers = data.prds_reviewers || []
+  const prds_tasks = data.prds_tasks || []
+
+  const start = (page - 1) * pageSize
+  const paginated = prds.slice(start, start + pageSize)
+
+  return NextResponse.json({
+    prds: paginated,
+    total: prds.length,
+    prds_reviewers,
+    prds_tasks
+  })
+}

--- a/src/app/api/my-work/set-deadline/route.ts
+++ b/src/app/api/my-work/set-deadline/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+import path from 'path'
+import fs from 'fs/promises'
+import { Prd } from '@/types/my-work'
+
+export async function POST(request: Request) {
+  const { prdId, dueDate } = await request.json()
+  const dataPath = path.join(process.cwd(), 'src/data/myWork.json')
+  const data = JSON.parse(await fs.readFile(dataPath, 'utf8'))
+  const prds: Prd[] = data.prds || []
+  const prd = prds.find(p => p.id === prdId)
+  if (!prd) {
+    return NextResponse.json({ error: 'PRD not found' }, { status: 404 })
+  }
+  prd.due_date = dueDate
+  await fs.writeFile(dataPath, JSON.stringify(data, null, 2))
+  return NextResponse.json({ prd })
+}

--- a/src/app/my-work/page.tsx
+++ b/src/app/my-work/page.tsx
@@ -1,0 +1,10 @@
+import MyWorkPage from '@/components/my-work/MyWorkPage'
+import AppShell from '@/components/AppShell'
+
+export default function MyWork() {
+  return (
+    <AppShell>
+      <MyWorkPage />
+    </AppShell>
+  )
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -25,6 +25,11 @@ export default function Sidebar() {
       href: "/key-terms",
       label: "Key Terms",
       icon: <BookOpen className="w-4 h-4" />,
+    },
+    {
+      href: "/my-work",
+      label: "My Work",
+      icon: <BookOpen className="w-4 h-4" />,
     }
   ];
 

--- a/src/components/my-work/DeadlineBadge.tsx
+++ b/src/components/my-work/DeadlineBadge.tsx
@@ -1,0 +1,10 @@
+"use client"
+
+import { differenceInCalendarDays, parseISO } from 'date-fns'
+
+export default function DeadlineBadge({ dueDate }: { dueDate?: string | null }) {
+  if (!dueDate) return null
+  const days = differenceInCalendarDays(parseISO(dueDate), new Date())
+  const text = days >= 0 ? `due in ${days}d` : `${Math.abs(days)}d late`
+  return <span className="text-xs text-muted-foreground">{text}</span>
+}

--- a/src/components/my-work/MyWorkPage.tsx
+++ b/src/components/my-work/MyWorkPage.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useState } from 'react'
-import { Prd, Task } from '@/types/my-work'
+import { Prd } from '@/types/my-work'
 import PrdCard from './PrdCard'
 
 export default function MyWorkPage() {

--- a/src/components/my-work/MyWorkPage.tsx
+++ b/src/components/my-work/MyWorkPage.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+import { Prd, Task } from '@/types/my-work'
+import PrdCard from './PrdCard'
+
+export default function MyWorkPage() {
+  const [prds, setPrds] = useState<Prd[]>([])
+
+  useEffect(() => {
+    const fetchPrds = async () => {
+      const res = await fetch('/api/my-work/list')
+      if (res.ok) {
+        const data = await res.json()
+        setPrds(data.prds as Prd[])
+      }
+    }
+    fetchPrds()
+  }, [])
+
+  return (
+    <div className="p-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+      {prds.map(prd => (
+        <PrdCard key={prd.id} prd={prd} />
+      ))}
+      {prds.length === 0 && (
+        <p className="text-center col-span-full text-muted-foreground">No PRDs yet</p>
+      )}
+    </div>
+  )
+}

--- a/src/components/my-work/PrdCard.tsx
+++ b/src/components/my-work/PrdCard.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { Prd } from '@/types/my-work'
+import DeadlineBadge from './DeadlineBadge'
+import ReviewerAvatars from './ReviewerAvatars'
+import TaskList from './TaskList'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+
+export default function PrdCard({ prd }: { prd: Prd }) {
+  return (
+    <Card className="bg-white">
+      <CardHeader>
+        <CardTitle className="flex justify-between items-center">
+          <span>{prd.title}</span>
+          <DeadlineBadge dueDate={prd.due_date} />
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ReviewerAvatars prdId={prd.id} />
+        <TaskList prdId={prd.id} />
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/my-work/ReviewerAvatars.tsx
+++ b/src/components/my-work/ReviewerAvatars.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+import { Reviewer } from '@/types/my-work'
+
+export default function ReviewerAvatars({ prdId }: { prdId: string }) {
+  const [reviewers, setReviewers] = useState<Reviewer[]>([])
+
+  useEffect(() => {
+    const fetchReviewers = async () => {
+      const res = await fetch('/api/my-work/list')
+      if (res.ok) {
+        const data = await res.json()
+        const all = (data.prds_reviewers || []) as Reviewer[]
+        setReviewers(all.filter((r) => r.prd_id === prdId))
+      }
+    }
+    fetchReviewers()
+  }, [prdId])
+
+  return (
+    <div className="flex space-x-2 mb-2">
+      {reviewers.map((rev) => (
+        <span key={rev.user_id} className="w-6 h-6 rounded-full bg-poppy text-white flex items-center justify-center text-xs">
+          {rev.user_id.slice(0, 2).toUpperCase()}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/src/components/my-work/TaskList.tsx
+++ b/src/components/my-work/TaskList.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+import { Task } from '@/types/my-work'
+
+export default function TaskList({ prdId }: { prdId: string }) {
+  const [tasks, setTasks] = useState<Task[]>([])
+
+  useEffect(() => {
+    const fetchTasks = async () => {
+      const res = await fetch('/api/my-work/list')
+      if (res.ok) {
+        const data = await res.json()
+        const all = (data.prds_tasks || []) as Task[]
+        setTasks(all.filter((t) => t.prd_id === prdId))
+      }
+    }
+    fetchTasks()
+  }, [prdId])
+
+  return (
+    <ul className="space-y-1">
+      {tasks.map((task) => (
+        <li key={task.id} className="flex items-center space-x-2">
+          <input type="checkbox" checked={task.is_done} readOnly className="h-4 w-4" />
+          <span className="text-sm">{task.title}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/data/myWork.json
+++ b/src/data/myWork.json
@@ -1,0 +1,42 @@
+{
+  "prds": [
+    {
+      "id": "1",
+      "title": "Example PRD",
+      "status": "Draft",
+      "owner_id": "1",
+      "due_date": null,
+      "created_at": "2024-05-01T00:00:00Z"
+    }
+  ],
+  "prds_reviewers": [
+    {
+      "prd_id": "1",
+      "user_id": "2",
+      "role": "reviewer"
+    }
+  ],
+  "prds_tasks": [
+    {
+      "id": "1",
+      "prd_id": "1",
+      "title": "Draft",
+      "is_done": false,
+      "sort_order": 1
+    },
+    {
+      "id": "2",
+      "prd_id": "1",
+      "title": "Review",
+      "is_done": false,
+      "sort_order": 2
+    },
+    {
+      "id": "3",
+      "prd_id": "1",
+      "title": "Final",
+      "is_done": false,
+      "sort_order": 3
+    }
+  ]
+}

--- a/src/types/my-work.ts
+++ b/src/types/my-work.ts
@@ -1,0 +1,22 @@
+export interface Prd {
+  id: string
+  title: string
+  status: 'Draft' | 'Review' | 'Final'
+  due_date?: string | null
+  owner_id: string
+  created_at: string
+}
+
+export interface Reviewer {
+  prd_id: string
+  user_id: string
+  role: string
+}
+
+export interface Task {
+  id: string
+  prd_id: string
+  title: string
+  is_done: boolean
+  sort_order: number
+}


### PR DESCRIPTION
## Summary
- scaffold My Work types and seed data
- add API endpoints for listing PRDs and editing deadlines/tasks
- implement simple dashboard components
- link to My Work from sidebar
- include `date-fns` dependency

## Testing
- `pnpm test` *(fails: vitest not found)*