### PR TITLE
Integrate Google Calendar API

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,6 @@ Local development requires a `.env.local` file containing values for:
 - `GOOGLE_CLIENT_SECRET`
 - `GOOGLE_REDIRECT_URI`
 - `PINECONE_API_KEY`
+- `GOOGLE_CALENDAR_ID` (optional, defaults to the authenticated user's primary calendar)
 
 Ask the maintainer to provide these values.

--- a/src/app/api/google-calendar/create-event/route.ts
+++ b/src/app/api/google-calendar/create-event/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { getAuthServerSession } from '@/lib/auth';
+import { getCalendarClient } from '@/lib/calendar';
+
+interface CreateEventRequest {
+  title: string;
+  attendees?: string[];
+  start: string; // ISO date string
+  end: string;   // ISO date string
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await getAuthServerSession();
+    if (!session?.accessToken) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    }
+
+    const { title, attendees = [], start, end } = (await request.json()) as CreateEventRequest;
+
+    if (!title || !start || !end) {
+      return NextResponse.json({ error: 'Missing event details' }, { status: 400 });
+    }
+
+    const calendar = getCalendarClient(session.accessToken);
+    const calendarId = process.env.GOOGLE_CALENDAR_ID || 'primary';
+
+    await calendar.events.insert({
+      calendarId,
+      requestBody: {
+        summary: title,
+        start: { dateTime: start },
+        end: { dateTime: end },
+        attendees: attendees.map(email => ({ email })),
+      },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error creating calendar event:', error);
+    return NextResponse.json(
+      { error: 'Failed to create event' },
+      { status: 500 }
+    );
+  }
+}
+

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -35,7 +35,8 @@ export const authOptions: NextAuthOptions = {
             "openid email profile " +
             "https://www.googleapis.com/auth/drive " +
             "https://www.googleapis.com/auth/documents " +
-            "https://www.googleapis.com/auth/spreadsheets.readonly",
+            "https://www.googleapis.com/auth/spreadsheets.readonly " +
+            "https://www.googleapis.com/auth/calendar",
           access_type: "offline",
           prompt: "consent",
         },

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,0 +1,18 @@
+import { google } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
+
+/**
+ * Initialize Google Calendar API client with the provided OAuth access token.
+ */
+export function getCalendarClient(accessToken: string) {
+  const auth = new OAuth2Client({
+    clientId: process.env.GOOGLE_CLIENT_ID,
+    clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    redirectUri: process.env.GOOGLE_REDIRECT_URI,
+  });
+
+  auth.setCredentials({ access_token: accessToken });
+
+  return google.calendar({ version: 'v3', auth });
+}
+


### PR DESCRIPTION
## Summary
- add Google Calendar scope to authentication
- expose optional `GOOGLE_CALENDAR_ID` env var in README
- create helper to init Calendar API client
- add API route to create Calendar events

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*
- `pnpm test` *(fails: vitest not found)*