### PR TITLE
Add meeting scheduling logic

### DIFF
--- a/src/components/my-work/MyWorkPage.tsx
+++ b/src/components/my-work/MyWorkPage.tsx
@@ -89,6 +89,7 @@ export default function MyWorkPage() {
         const prdsWithComments = await Promise.all(
           savedPrds.map(async (prd) => {
             const { comments, last_modified } = await fetchComments(prd.id)
+            const summary = await fetchSummary(prd.id, comments, last_modified)
             return {
               id: prd.id,
               title: prd.title,
@@ -101,7 +102,7 @@ export default function MyWorkPage() {
               metadata: {
                 comments,
                 edit_history: [],
-                open_questions_summary: undefined
+                open_questions_summary: summary
               }
             }
           })

--- a/src/components/my-work/PrdCard.tsx
+++ b/src/components/my-work/PrdCard.tsx
@@ -1,6 +1,8 @@
 "use client"
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { shouldScheduleMeeting } from '@/lib/meetingLogic'
 import { Prd } from '@/types/my-work'
 import DeadlineBadge from './DeadlineBadge'
 import ReviewerAvatars from './ReviewerAvatars'
@@ -31,6 +33,24 @@ export default function PrdCard({
   const [summary, setSummary] = useState<string | undefined>(
     prd.metadata?.open_questions_summary
   )
+  const [needsMeeting, setNeedsMeeting] = useState(false)
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!summary) {
+      void ensureSummary()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (summary !== undefined) {
+      const result = shouldScheduleMeeting({
+        ...prd,
+        metadata: { ...(prd.metadata || {}), open_questions_summary: summary }
+      })
+      setNeedsMeeting(result)
+    }
+  }, [summary, prd])
 
   const ensureSummary = async (): Promise<string | undefined> => {
     if (summary) return summary
@@ -155,6 +175,19 @@ export default function PrdCard({
             <div className="pt-2 border-t border-gray-100">
               <ReviewerAvatars reviewers={prd.metadata?.reviewers || []} />
               <TaskList tasks={prd.metadata?.tasks || []} />
+              {needsMeeting && (
+                <div className="mt-2">
+                  <Button
+                    size="sm"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      router.push('/schedule')
+                    }}
+                  >
+                    Schedule Meeting
+                  </Button>
+                </div>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/src/lib/meetingLogic.ts
+++ b/src/lib/meetingLogic.ts
@@ -1,0 +1,22 @@
+import { Prd } from '@/types/my-work'
+
+/**
+ * Decide whether a meeting should be scheduled for a PRD based on
+ * unresolved comments, time since last edit and summary text.
+ */
+export function shouldScheduleMeeting(prd: Prd): boolean {
+  const unresolvedComments = prd.metadata?.comments?.filter(c => !c.resolved).length ?? 0
+  const daysSinceEdit = prd.last_edited_at
+    ? Math.ceil((Date.now() - new Date(prd.last_edited_at).getTime()) / (1000 * 60 * 60 * 24))
+    : Infinity
+
+  const summary = prd.metadata?.open_questions_summary?.toLowerCase() || ''
+  const summaryIndicatesConfusion = ['meeting', 'discuss', 'sync', 'blocked', 'alignment']
+    .some(word => summary.includes(word))
+
+  if (unresolvedComments > 10) return true
+  if (unresolvedComments > 0 && daysSinceEdit > 14) return true
+  if (summaryIndicatesConfusion) return true
+
+  return false
+}


### PR DESCRIPTION
## Summary
- add `shouldScheduleMeeting` helper
- fetch comment summary when loading PRDs
- show **Schedule Meeting** button on PRD cards when a meeting is suggested

## Testing
- `pnpm test` *(fails: vitest not found)*