### PR TITLE
Add meeting scheduling utilities and tests

### DIFF
--- a/src/__tests__/meetingLogic.test.ts
+++ b/src/__tests__/meetingLogic.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { shouldScheduleMeeting, createCalendarEvent, CalendarEvent } from '@/lib/meetingLogic'
+
+// Mock googleapis calendar API
+const insertMock = vi.fn()
+class OAuth2 {
+  setCredentials = vi.fn()
+}
+vi.mock('googleapis', () => {
+  return {
+    google: {
+      auth: { OAuth2 },
+      calendar: vi.fn(() => ({ events: { insert: insertMock } }))
+    }
+  }
+})
+
+describe('shouldScheduleMeeting', () => {
+  it('returns true when a comment includes meeting keywords', () => {
+    const comments = [
+      'Let\'s schedule a meeting to discuss this further.',
+      'I have some questions.'
+    ]
+    expect(shouldScheduleMeeting(comments)).toBe(true)
+  })
+
+  it('returns false when a comment explicitly states no meeting is needed', () => {
+    const comments = [
+      'We resolved the issue. No meeting necessary.'
+    ]
+    expect(shouldScheduleMeeting(comments)).toBe(false)
+  })
+
+  it('returns false when comments do not mention meetings', () => {
+    const comments = [
+      'Looks good to me',
+      'Ship it!'
+    ]
+    expect(shouldScheduleMeeting(comments)).toBe(false)
+  })
+
+  it('prefers negative phrases over meeting keywords', () => {
+    const comments = [
+      'Let\'s meet soon',
+      'Actually, don\'t schedule anything yet'
+    ]
+    expect(shouldScheduleMeeting(comments)).toBe(false)
+  })
+})
+
+describe('createCalendarEvent', () => {
+  const token = 'token'
+  const event: CalendarEvent = { summary: 'sync', start: '2024-01-01T10:00:00Z', end: '2024-01-01T10:30:00Z' }
+
+  it('returns true when event creation succeeds', async () => {
+    insertMock.mockResolvedValue({ data: { id: '1' } })
+    const result = await createCalendarEvent(token, event)
+    expect(result).toBe(true)
+    expect(insertMock).toHaveBeenCalled()
+  })
+
+  it('returns false when event creation fails', async () => {
+    insertMock.mockRejectedValue(new Error('fail'))
+    const result = await createCalendarEvent(token, event)
+    expect(result).toBe(false)
+    expect(insertMock).toHaveBeenCalled()
+  })
+})

--- a/src/lib/meetingLogic.ts
+++ b/src/lib/meetingLogic.ts
@@ -1,0 +1,55 @@
+export interface CalendarEvent {
+  summary: string
+  start: string
+  end: string
+}
+
+/**
+ * Determine whether a meeting should be scheduled based on comment content.
+ * Returns true if any comment contains meeting related keywords unless a
+ * comment explicitly states that no meeting is needed.
+ */
+export function shouldScheduleMeeting(comments: string[]): boolean {
+  const denyPhrases = ['no meeting', "don't schedule", 'no need to meet']
+  const meetingKeywords = ['meet', 'meeting', 'call', 'schedule', 'zoom', 'hangout', 'sync']
+
+  let foundKeyword = false
+
+  for (const comment of comments) {
+    const lower = comment.toLowerCase()
+    if (denyPhrases.some(p => lower.includes(p))) {
+      return false
+    }
+    if (meetingKeywords.some(k => lower.includes(k))) {
+      foundKeyword = true
+    }
+  }
+
+  return foundKeyword
+}
+
+import { google } from 'googleapis'
+
+/**
+ * Create a calendar event using the Google Calendar API.
+ * Returns true if the event was successfully created, otherwise false.
+ */
+export async function createCalendarEvent(accessToken: string, event: CalendarEvent): Promise<boolean> {
+  const auth = new google.auth.OAuth2()
+  auth.setCredentials({ access_token: accessToken })
+  const calendar = google.calendar({ version: 'v3', auth })
+  try {
+    await calendar.events.insert({
+      calendarId: 'primary',
+      requestBody: {
+        summary: event.summary,
+        start: { dateTime: event.start },
+        end: { dateTime: event.end }
+      }
+    })
+    return true
+  } catch (err) {
+    console.error('Error creating calendar event:', err)
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- add `shouldScheduleMeeting` and `createCalendarEvent` utilities
- provide unit tests for meeting logic and calendar creation

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*
- `pnpm test --run --reporter verbose` *(fails: vitest not found)*