### PR TITLE
Add calendar credential docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ Local development requires a `.env.local` file containing values for:
 - `PINECONE_API_KEY`
 
 Ask the maintainer to provide these values.
+
+## Google Calendar Integration
+
+Poppy connects to your calendar using these Google credentials. When team members comment on a PRD, Poppy analyzes the discussion and surfaces suggested meeting times. The app checks availability via Google Calendar and recommends sessions like scoping or design reviews directly in the chat.

--- a/src/app/instructions/page.tsx
+++ b/src/app/instructions/page.tsx
@@ -76,12 +76,17 @@ export default function InstructionsPage() {
                   <li>Tracks outreach in the feedback sheet</li>
                 </ul>
               </li>
-            </ul>
-          </div>
+          </ul>
+        </div>
 
-          <div className="mt-8 text-center text-primary/70 text-base">
-            Need help? Ask Poppy in the chat or check the documentation for tips and best practices.
-          </div>
+        <div className="space-y-4">
+          <h2 className="text-2xl font-semibold text-poppy">Meeting Recommendations</h2>
+          <p className="text-lg">When PRDs spark discussion, Poppy looks for action items and suggests times to meet. Connect your Google Calendar so the app can check availability and propose reviews directly in chat.</p>
+        </div>
+
+        <div className="mt-8 text-center text-primary/70 text-base">
+          Need help? Ask Poppy in the chat or check the documentation for tips and best practices.
+        </div>
         </div>
       </div>
     </AppShell>


### PR DESCRIPTION
## Summary
- document Google Calendar integration
- mention meeting recommendations in the instructions

## Testing
- `npm test` *(fails: vitest not found)*