### PR TITLE
Add document generation service

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useState, useRef, useEffect } from 'react';
 import { collectStream } from "@/lib/collectStream"
+import { generateDocument } from '@/lib/services/documentGenerator'
 import { FileText, Sparkles, Calendar, Target } from "lucide-react"
 import { motion, AnimatePresence } from "framer-motion";
 
@@ -181,15 +182,6 @@ export default function ChatInterface() {
   const generateContent = async () => {
     try {
       setLoading(true);
-      // Format questions and answers for the content generation
-      const questionsWithAnswers = questions.map(q => ({
-        id: q.id,
-        text: q.text,
-        reasoning: q.reasoning,
-        answer: questionAnswers[q.id]
-      }));
-      const storedContext = localStorage.getItem("personalContext");
-      const teamTerms = JSON.parse(localStorage.getItem("teamTerms") || "{}");
 
       // Show writing message
       setMessages(prev => [...prev, {
@@ -197,31 +189,12 @@ export default function ChatInterface() {
         content: <span className="animate-pulse">I&apos;m writing your PRD document now...</span>
       }]);
 
-      const contentResponse = await fetch("/api/generate-content", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          title: "Draft PRD",
-          query: messages[1].content, // The initial product idea
-          matchedContext: matchedContext,
-          type: 'prd',
-          storedContext: storedContext,
-          questions: questionsWithAnswers,
-          teamTerms: teamTerms
-        }),
-      });
-      const contentText = await collectStream(contentResponse);
-
-      // Create Google Doc
-      const docResponse = await fetch("/api/create-google-doc", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          title: "Draft PRD",
-          content: contentText
-        }),
-      });
-      const docData = await docResponse.json();
+      const docData = await generateDocument(
+        'prd',
+        'Draft PRD',
+        typeof messages[1].content === 'string' ? messages[1].content : String(messages[1].content),
+        questionAnswers
+      )
       console.log('Doc response:', docData); // Add logging to debug
 
       if (!docData.url) {

--- a/src/components/StrategyForm.tsx
+++ b/src/components/StrategyForm.tsx
@@ -6,7 +6,7 @@ import { motion, AnimatePresence } from "framer-motion"
 import { Target } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import QuestionsForm from "./QuestionsForm"
-import { collectStream } from "@/lib/collectStream"
+import { generateDocument } from "@/lib/services/documentGenerator"
 
 interface Question {
   id: string
@@ -202,58 +202,7 @@ export default function StrategyForm() {
       setIsGenerating(true)
       setIsGeneratingQuestions(false)
 
-      // 1. Get embedding for the query
-      const embedRes = await fetch("/api/embed-request", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title, query }),
-      })
-      if (!embedRes.ok) throw new Error("Failed to get embedding")
-      const { queryEmbedding } = await embedRes.json()
-      if (!queryEmbedding || !Array.isArray(queryEmbedding)) throw new Error("Invalid embedding response")
-
-      const embedding = queryEmbedding[0].embedding
-
-      // 2. Get matched context from Pinecone
-      const matchRes = await fetch("/api/match-embeds", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(embedding),
-      })
-      if (!matchRes.ok) throw new Error("Failed to match embeddings")
-      const { matchedContext } = await matchRes.json()
-      if (!matchedContext || !Array.isArray(matchedContext)) throw new Error("Invalid matched context response")
-
-      // 3. Generate strategy content
-      const storedContext = localStorage.getItem("personalContext")
-      const teamTerms = JSON.parse(localStorage.getItem("teamTerms") || "{}")
-      const genRes = await fetch("/api/generate-content", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          type: "strategy",
-          title,
-          query,
-          teamTerms,
-          storedContext,
-          additionalContext: matchedContext.join("\n"),
-          questionAnswers,
-        }),
-      })
-
-      const markdown = await collectStream(genRes)
-
-      // 4. Create Google Doc
-      const docRes = await fetch("/api/create-google-doc", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          title: title,
-          content: markdown,
-        }),
-      })
-      if (!docRes.ok) throw new Error("Failed to create Google Doc")
-      const docData = await docRes.json()
+      const docData = await generateDocument('strategy', title, query, questionAnswers)
 
       if (docData && docData.url) {
         setShowDocLink(true)

--- a/src/lib/services/documentGenerator.ts
+++ b/src/lib/services/documentGenerator.ts
@@ -1,0 +1,75 @@
+import { collectStream } from "../collectStream"
+export async function generateDocument(
+  type: string,
+  title: string,
+  query: string,
+  answers?: Record<string, string>
+) {
+  // 1. Embed request
+  const embedRes = await fetch('/api/embed-request', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title, query })
+  })
+  if (!embedRes.ok) throw new Error('Failed to get embedding')
+  const { queryEmbedding } = await embedRes.json()
+  if (!queryEmbedding || !Array.isArray(queryEmbedding)) throw new Error('Invalid embedding response')
+  const embedding = queryEmbedding[0].embedding
+
+  // 2. Match embeddings
+  const matchRes = await fetch('/api/match-embeds', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(embedding)
+  })
+  if (!matchRes.ok) throw new Error('Failed to match embeddings')
+  const { matchedContext } = await matchRes.json()
+  if (!matchedContext || !Array.isArray(matchedContext)) throw new Error('Invalid matched context response')
+
+  // 3. Generate vocabulary
+  const vocabRes = await fetch('/api/generate-vocabulary', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title, query, matchedContext, type })
+  })
+  if (!vocabRes.ok) throw new Error('Failed to generate vocabulary')
+  await vocabRes.json()
+
+  const storedContext = localStorage.getItem('personalContext')
+  const teamTerms = JSON.parse(localStorage.getItem('teamTerms') || '{}')
+
+  // 4. Generate questions
+  const questionsRes = await fetch('/api/generate-questions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title, query, matchedContext, storedContext, teamTerms, type })
+  })
+  if (!questionsRes.ok) throw new Error('Failed to generate questions')
+  await questionsRes.json()
+
+  // 5. Generate content
+  const contentRes = await fetch('/api/generate-content', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      type,
+      title,
+      query,
+      teamTerms,
+      storedContext,
+      additionalContext: matchedContext.join('\n'),
+      questionAnswers: answers
+    })
+  })
+  const markdown = await collectStream(contentRes)
+
+  // 6. Create Google Doc
+  const docRes = await fetch('/api/create-google-doc', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title, content: markdown })
+  })
+  if (!docRes.ok) throw new Error('Failed to create Google Doc')
+  const docData = await docRes.json()
+  return docData
+}


### PR DESCRIPTION
## Summary
- create `generateDocument` service for composing API calls
- use the service in DraftForm, StrategyForm and ChatInterface
- cast message content to string when calling the service

## Testing
- `pnpm lint` *(fails: `next` not found)*
- `pnpm test` *(fails: `vitest` not found)*