### PR TITLE
Remove duplicate Question interface

### DIFF
--- a/src/app/api/generate-brand-questions/route.ts
+++ b/src/app/api/generate-brand-questions/route.ts
@@ -3,16 +3,11 @@ import { getUserIndex } from '@/lib/pinecone';
 import { getAuthServerSession } from '@/lib/auth';
 import { OpenAI } from 'openai';
 import { embedChunks } from '@/app/embed';
+import type { Question } from '@/types/question';
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 });
-
-export interface Question {
-  id?: string;
-  text: string;
-  reasoning: string;
-}
 
 export interface QuestionsResponse {
   questions: Question[];

--- a/src/lib/services/openaiService.ts
+++ b/src/lib/services/openaiService.ts
@@ -3,6 +3,7 @@ import OpenAI from 'openai';
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 import { openai } from '../openai';
 import { terms } from '../constants/terms';
+import type { Question } from '@/types/question';
 
 export { terms };
 
@@ -75,7 +76,6 @@ I've included instructions for how to think and write PRDs like a product manage
   return streamTextResponse(stream);
 }
 
-export interface Question { id?: string; text: string; reasoning: string; }
 export interface QuestionsResponse { questions: Question[]; internalTerms: string[]; }
 export interface GenerateQuestionsRequest {
   title: string;


### PR DESCRIPTION
## Summary
- import Question type in `openaiService`
- use shared Question type in brand questions API

## Testing
- `pnpm test` *(fails: vitest not found)*