### PR TITLE
Centralize OpenAI usage

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,12 +1,9 @@
 import { NextResponse } from 'next/server';
-import OpenAI from 'openai';
-import { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+import { openai } from '@/lib/openai';
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 
 export const dynamic = 'force-dynamic';
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
 
 interface ChatMessage {
   role: 'user' | 'assistant';

--- a/src/app/api/embed-feedback/route.ts
+++ b/src/app/api/embed-feedback/route.ts
@@ -1,13 +1,9 @@
 import { NextResponse } from 'next/server';
 import { getAuthServerSession } from '@/lib/auth';
 import { getUserIndex } from '@/lib/pinecone';
-import OpenAI from 'openai';
+import { openai } from '@/lib/openai';
 import { nanoid } from 'nanoid';
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-  organization: process.env.OPENAI_ORGANIZATION,
-});
 
 interface FeedbackRow {
   RECIPIENT_EMAIL: string;

--- a/src/app/api/generate-brand-messaging/route.ts
+++ b/src/app/api/generate-brand-messaging/route.ts
@@ -1,13 +1,10 @@
 import { NextResponse } from 'next/server';
 import { getUserIndex } from '@/lib/pinecone';
 import { getAuthServerSession } from '@/lib/auth';
-import { OpenAI } from 'openai';
+import { openai } from '@/lib/openai';
 import { embedChunks } from '@/app/embed';
 import { Question } from '@/types/question';
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
 
 export async function POST(request: Request) {
   try {

--- a/src/app/api/generate-brand-questions/route.ts
+++ b/src/app/api/generate-brand-questions/route.ts
@@ -1,12 +1,9 @@
 import { NextResponse } from 'next/server';
 import { getUserIndex } from '@/lib/pinecone';
 import { getAuthServerSession } from '@/lib/auth';
-import { OpenAI } from 'openai';
+import { openai } from '@/lib/openai';
 import { embedChunks } from '@/app/embed';
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
 
 export interface Question {
   id?: string;

--- a/src/app/api/prd/summarize-comments/route.ts
+++ b/src/app/api/prd/summarize-comments/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import OpenAI from 'openai'
+import { openai } from '@/lib/openai'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 
@@ -10,9 +10,6 @@ interface CacheEntry {
 
 const summaryCache = new Map<string, CacheEntry>()
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY
-})
 
 export async function POST(request: Request) {
   try {

--- a/src/app/chunk.ts
+++ b/src/app/chunk.ts
@@ -1,4 +1,4 @@
-import OpenAI from 'openai';
+import { openai } from '@/lib/openai';
 
 /**
  * Splits a given text into chunks of 1 to many paragraphs.
@@ -54,10 +54,6 @@ export function chunkTextByMultiParagraphs(
     export async function enhanceChunks(chunks: string[]) {
         const enhancedChunks: string[] = [];
         for (const chunk of chunks) {
-            const openai = new OpenAI({
-                apiKey: process.env.OPENAI_API_KEY,
-                organization: process.env.OPENAI_ORGANIZATION,
-            });
             const completion = await openai.chat.completions.create({
                 model: "gpt-4o-mini",
                 messages: [

--- a/src/app/embed.ts
+++ b/src/app/embed.ts
@@ -1,4 +1,5 @@
-import OpenAI from "openai";
+import type OpenAI from "openai";
+import { openai } from "@/lib/openai";
 import { enhanceChunks } from "./chunk";
 import { nanoid } from "nanoid"; 
 
@@ -12,10 +13,6 @@ export const maxDuration = 60;
 export async function embedChunks(
   chunks: string[]
 ): Promise<OpenAIEmbedding[]> {
-  const openai = new OpenAI({
-    apiKey: process.env.OPENAI_API_KEY,
-    organization: "org-4sVYvNZQTa4dYOT8bAgyz8gu",
-  });
 
   try {
     const res = await openai.embeddings.create({

--- a/src/app/search.ts
+++ b/src/app/search.ts
@@ -1,4 +1,4 @@
-import OpenAI from 'openai';
+import { openai } from '@/lib/openai';
 
 export async function writeSummary(question: string, additionalContext: string, teamStrategy: string, howYouThinkAboutProduct: string, pillarGoalsKeyTermsBackground: string, examplesOfHowYouThink: string, questions: string[]) {
     const terms = {
@@ -102,10 +102,6 @@ export async function writeSummary(question: string, additionalContext: string, 
         "Benchmarks tab in Customer Hub": "Compares a brand's support metrics to industry peers once connected.",
         "Deliverability Health alerts": "Automated warnings that flag rising spam or bounces and recommend fixes"
       }
-        const openai = new OpenAI({
-            apiKey: process.env.OPENAI_API_KEY,
-            organization: 'org-4sVYvNZQTa4dYOT8bAgyz8gu',
-        });
         const completion = await openai.chat.completions.create({
             model: "o3",
             messages: [

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -1,8 +1,4 @@
-import OpenAI from 'openai';
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+import { openai } from '@/lib/openai';
 
 export async function getEmbedding(text: string): Promise<number[]> {
   const response = await openai.embeddings.create({


### PR DESCRIPTION
## Summary
- reuse shared `openai` instance across API routes and utilities
- remove inline `new OpenAI` constructions

## Testing
- `pnpm test` *(fails: vitest not found)*