### PR TITLE
Refactor API auth handling

### DIFF
--- a/src/app/api/chunk-docs/route.ts
+++ b/src/app/api/chunk-docs/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { google } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { chunkTextByMultiParagraphs } from '@/app/chunk';
 
 
@@ -11,12 +11,8 @@ interface DocumentContent {
   content: string;
 }
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.user?.name) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
     
     const body = await request.json();
     const documentId = body.documentId;
@@ -36,7 +32,7 @@ export async function POST(request: Request) {
     });
 
     // Set the access token from the session
-    if (!authSession.accessToken) {
+    if (!session.accessToken) {
       return NextResponse.json(
         { error: 'Not authenticated' },
         { status: 401 }
@@ -44,7 +40,7 @@ export async function POST(request: Request) {
     }
 
     auth.setCredentials({
-      access_token: authSession.accessToken,
+      access_token: session.accessToken,
     });
 
     // Initialize the Drive API
@@ -92,4 +88,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-} 
+}); 

--- a/src/app/api/create-google-doc/route.ts
+++ b/src/app/api/create-google-doc/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { google } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.accessToken) {
+    if (!session.accessToken) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
     }
 
@@ -20,7 +19,7 @@ export async function POST(request: Request) {
     });
 
     auth.setCredentials({
-      access_token: authSession.accessToken,
+      access_token: session.accessToken,
     });
 
     // Initialize the Drive API
@@ -49,4 +48,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-}
+});

--- a/src/app/api/delete-prd/route.ts
+++ b/src/app/api/delete-prd/route.ts
@@ -4,13 +4,6 @@ import { withAuth } from '@/lib/api';
 import { OAuth2Client } from 'google-auth-library';
 
 export const POST = withAuth(async (session: Session, request: Request) => {
-  interface Session {
-    accessToken?: string;
-    user?: {
-      name?: string;
-      email?: string;
-    };
-  }
   // Blank body for now
   try{ 
 

--- a/src/app/api/delete-prd/route.ts
+++ b/src/app/api/delete-prd/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
 import { google } from 'googleapis';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { OAuth2Client } from 'google-auth-library';
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session: Session, request: Request) => {
   interface Session {
     accessToken?: string;
     user?: {
@@ -22,7 +22,6 @@ export async function POST(request: Request) {
     });
 
     // Set the access token from the session
-    const session = await getAuthServerSession() as Session;
     if (!session?.accessToken) {
       return NextResponse.json(
         { error: 'Not authenticated' },
@@ -51,4 +50,4 @@ export async function POST(request: Request) {
     );
   }
   return NextResponse.json({}, { status: 200 });
-} 
+}); 

--- a/src/app/api/embed-chunks/route.ts
+++ b/src/app/api/embed-chunks/route.ts
@@ -1,14 +1,10 @@
 import { NextResponse } from 'next/server';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { buildPineconeRecords } from '@/app/embed';
 import { headers } from 'next/headers';
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.user?.name) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
     
     const body = await request.json();
     const chunks = body.chunks;
@@ -46,4 +42,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-} 
+}); 

--- a/src/app/api/embed-feedback/route.ts
+++ b/src/app/api/embed-feedback/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { getUserIndex } from '@/lib/pinecone';
 import OpenAI from 'openai';
 import { nanoid } from 'nanoid';
@@ -48,12 +48,8 @@ async function enrichFeedback(feedback: string): Promise<string> {
   return `${feedback}\n\nTopics: ${analysis.topics.join(', ')}\nThemes: ${analysis.themes.join(', ')}\nFeatures: ${analysis.features.join(', ')}\nSentiment: ${analysis.sentiment}`;
 }
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.user?.name) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     const index = getUserIndex('feedback');
     const { rows } = await request.json();
@@ -108,4 +104,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-} 
+}); 

--- a/src/app/api/embed-request/route.ts
+++ b/src/app/api/embed-request/route.ts
@@ -1,14 +1,10 @@
 import { NextResponse } from 'next/server';
 import { embedChunks } from '@/app/embed';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { headers } from 'next/headers';
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.user?.name) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     const headersList = await headers();
     const referer = headersList.get('referer') || '';
@@ -47,4 +43,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-} 
+}); 

--- a/src/app/api/fetch-sheets/route.ts
+++ b/src/app/api/fetch-sheets/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { google } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 
 interface SheetData {
   id: string;
@@ -12,12 +12,8 @@ interface SheetData {
   }>;
 }
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.user?.name) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     const { documentId } = await request.json();
     if (!documentId) {
@@ -30,10 +26,10 @@ export async function POST(request: Request) {
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
       redirectUri: process.env.GOOGLE_REDIRECT_URI,
     });
-    if (!authSession.accessToken) {
+    if (!session.accessToken) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
     }
-    auth.setCredentials({ access_token: authSession.accessToken });
+    auth.setCredentials({ access_token: session.accessToken });
 
     // Initialize Google Sheets API
     const sheets = google.sheets({ version: 'v4', auth });
@@ -83,4 +79,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-}
+});

--- a/src/app/api/generate-brand-messaging/route.ts
+++ b/src/app/api/generate-brand-messaging/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getUserIndex } from '@/lib/pinecone';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { OpenAI } from 'openai';
 import { embedChunks } from '@/app/embed';
 import { Question } from '@/types/question';
@@ -9,14 +9,10 @@ const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 });
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.user?.name) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
-    const formattedUsername = authSession.user.name
+    const formattedUsername = session.user.name
       .toLowerCase()
       .replace(/[^a-z0-9-]/g, '-')
       .replace(/-+/g, '-')
@@ -96,4 +92,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-} 
+}); 

--- a/src/app/api/generate-brand-questions/route.ts
+++ b/src/app/api/generate-brand-questions/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getUserIndex } from '@/lib/pinecone';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { OpenAI } from 'openai';
 import { embedChunks } from '@/app/embed';
 
@@ -18,14 +18,10 @@ export interface QuestionsResponse {
   questions: Question[];
 }
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.user?.name) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
-    const formattedUsername = authSession.user.name
+    const formattedUsername = session.user.name
       .toLowerCase()
       .replace(/[^a-z0-9-]/g, '-')
       .replace(/-+/g, '-')
@@ -122,4 +118,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-} 
+}); 

--- a/src/app/api/generate-content/route.ts
+++ b/src/app/api/generate-content/route.ts
@@ -1,16 +1,11 @@
 import { NextResponse } from 'next/server';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { generateContent, type GenerateContentRequest } from '@/lib/services/openaiService';
 
 export const dynamic = 'force-dynamic';
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const session = await getAuthServerSession();
-    if (!session?.user?.name) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     const body = (await request.json()) as GenerateContentRequest;
     return await generateContent(body);
   } catch (err) {
@@ -20,4 +15,4 @@ export async function POST(request: Request) {
       { status: 500 },
     );
   }
-}
+});

--- a/src/app/api/generate-questions/route.ts
+++ b/src/app/api/generate-questions/route.ts
@@ -1,13 +1,9 @@
 import { NextResponse } from 'next/server';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { generateQuestions, type GenerateQuestionsRequest } from '@/lib/services/openaiService';
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.user?.name) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
     const body = await request.json() as GenerateQuestionsRequest;
     const result = await generateQuestions(body);
     return NextResponse.json(result);
@@ -18,4 +14,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-}
+});

--- a/src/app/api/generate-vocabulary/route.ts
+++ b/src/app/api/generate-vocabulary/route.ts
@@ -1,13 +1,9 @@
 import { NextResponse } from 'next/server';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { generateVocabulary } from '@/lib/services/openaiService';
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.user?.name) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     const { title, query, matchedContext, type } = await request.json();
     const result = await generateVocabulary({ title, query, matchedContext, type });
@@ -19,4 +15,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-}
+});

--- a/src/app/api/get-email/route.ts
+++ b/src/app/api/get-email/route.ts
@@ -1,14 +1,10 @@
 import { NextResponse } from 'next/server';
 import { google } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.user?.name) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     const { documentId, rowNumber, columnIndex } = await request.json();
     
@@ -25,10 +21,10 @@ export async function POST(request: Request) {
       redirectUri: process.env.GOOGLE_REDIRECT_URI,
     });
 
-    if (!authSession.accessToken) {
+    if (!session.accessToken) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
     }
-    auth.setCredentials({ access_token: authSession.accessToken });
+    auth.setCredentials({ access_token: session.accessToken });
 
     // Initialize Google Sheets API
     const sheets = google.sheets({ version: 'v4', auth });
@@ -99,4 +95,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-} 
+}); 

--- a/src/app/api/get-google-doc-content/route.ts
+++ b/src/app/api/get-google-doc-content/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
 import { google } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.accessToken) {
+    if (!session.accessToken) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
     }
 
@@ -21,7 +20,7 @@ export async function POST(request: Request) {
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
       redirectUri: process.env.GOOGLE_REDIRECT_URI,
     });
-    auth.setCredentials({ access_token: authSession.accessToken });
+    auth.setCredentials({ access_token: session.accessToken });
 
     // Initialize the Drive API
     const drive = google.drive({ version: 'v3', auth });
@@ -40,4 +39,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-} 
+}); 

--- a/src/app/api/google-calendar/create-event/route.ts
+++ b/src/app/api/google-calendar/create-event/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { getCalendarClient } from '@/lib/calendar';
 
 interface CreateEventRequest {
@@ -9,10 +9,9 @@ interface CreateEventRequest {
   end: string;   // ISO date string
 }
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const session = await getAuthServerSession();
-    if (!session?.accessToken) {
+    if (!session.accessToken) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
     }
 
@@ -43,5 +42,5 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-}
+});
 

--- a/src/app/api/google-calendar/find-availability/route.ts
+++ b/src/app/api/google-calendar/find-availability/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { getCalendarClient } from '@/lib/calendar';
 
 interface FindAvailabilityRequest {
@@ -46,10 +46,9 @@ function getNextWorkingHourStart(date: Date): Date {
   return next;
 }
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const session = await getAuthServerSession();
-    if (!session?.accessToken) {
+    if (!session.accessToken) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
     }
 
@@ -199,5 +198,5 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-} 
+}); 
 

--- a/src/app/api/init-pinecone/route.ts
+++ b/src/app/api/init-pinecone/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
 import { Pinecone } from '@pinecone-database/pinecone';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 
-export async function POST() {
+export const POST = withAuth(async (session) => {
   try {
-    const authSession = await getAuthServerSession();
 
-    if (!authSession?.user?.name) {
+    if (!session?.user?.name) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
@@ -15,7 +14,7 @@ export async function POST() {
     });
 
     // Format username to comply with Pinecone naming requirements
-    const formattedUsername = authSession.user.name
+    const formattedUsername = session.user.name
       .toLowerCase()
       .replace(/[^a-z0-9-]/g, '-')
       .replace(/-+/g, '-') // Replace multiple consecutive hyphens with a single one
@@ -43,13 +42,13 @@ export async function POST() {
 
       return NextResponse.json({
         message: 'Pinecone index created successfully',
-        username: authSession.user.name,
+        username: session.user.name,
         indexName,
       });
     } else {
       return NextResponse.json({
         message: 'Pinecone index already exists',
-        username: authSession.user.name,
+        username: session.user.name,
         indexName,
       });
     }
@@ -60,4 +59,4 @@ export async function POST() {
       { status: 500 }
     );
   }
-}
+});

--- a/src/app/api/match-embeds/route.ts
+++ b/src/app/api/match-embeds/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getUserIndex } from '@/lib/pinecone';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { headers } from 'next/headers';
 import { Pinecone } from '@pinecone-database/pinecone';
 
@@ -9,19 +9,15 @@ const pc = new Pinecone({
 });
 
 
-export async function POST(req: NextRequest) {
+export const POST = withAuth(async (session, req: NextRequest) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.user?.name) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     const headersList = await headers();
     const referer = headersList.get('referer') || '';
     const isSchedulePage = referer.includes('/schedule');
 
     // Format username to comply with Pinecone naming requirements
-    const formattedUsername = authSession.user.name
+    const formattedUsername = session.user.name
       .toLowerCase()
       .replace(/[^a-z0-9-]/g, '-')
       .replace(/-+/g, '-')
@@ -76,4 +72,4 @@ export async function POST(req: NextRequest) {
   } catch (error) {
     return NextResponse.json({ error: error instanceof Error ? error.message : 'Unknown error' }, { status: 500 });
   }
-} 
+}); 

--- a/src/app/api/pinecone-upsert/route.ts
+++ b/src/app/api/pinecone-upsert/route.ts
@@ -1,16 +1,12 @@
 import { NextResponse } from 'next/server';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { getUserIndex } from '@/lib/pinecone';
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.user?.name) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     // Format username to comply with Pinecone naming requirements
-    const formattedUsername = authSession.user.name
+    const formattedUsername = session.user.name
       .toLowerCase()
       .replace(/[^a-z0-9-]/g, '-')
       .replace(/-+/g, '-') // Replace multiple consecutive hyphens with a single one
@@ -31,7 +27,7 @@ export async function POST(request: Request) {
     }
 
     // Set the access token from the session
-    if (!authSession.accessToken) {
+    if (!session.accessToken) {
       return NextResponse.json(
         { error: 'Not authenticated' },
         { status: 401 }
@@ -75,4 +71,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-} 
+}); 

--- a/src/app/api/resync-doc/route.ts
+++ b/src/app/api/resync-doc/route.ts
@@ -1,15 +1,11 @@
 import { NextResponse } from 'next/server';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 import { getUserIndex } from '@/lib/pinecone';
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.user?.name) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
-    const formattedUsername = authSession.user.name
+    const formattedUsername = session.user.name
       .toLowerCase()
       .replace(/[^a-z0-9-]/g, '-')
       .replace(/-+/g, '-')
@@ -28,7 +24,7 @@ export async function POST(request: Request) {
       );
     }
 
-    if (!authSession.accessToken) {
+    if (!session.accessToken) {
       return NextResponse.json(
         { error: 'Not authenticated' },
         { status: 401 }
@@ -55,4 +51,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-}
+});

--- a/src/app/api/update-sheet/route.ts
+++ b/src/app/api/update-sheet/route.ts
@@ -1,14 +1,10 @@
 import { NextResponse } from 'next/server';
 import { google } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
-import { getAuthServerSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api';
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (session, request: Request) => {
   try {
-    const authSession = await getAuthServerSession();
-    if (!authSession?.user?.name) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     const { documentId, klaviyoAccountId, feedbackData, email } = await request.json();
     
@@ -25,10 +21,10 @@ export async function POST(request: Request) {
       redirectUri: process.env.GOOGLE_REDIRECT_URI,
     });
 
-    if (!authSession.accessToken) {
+    if (!session.accessToken) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
     }
-    auth.setCredentials({ access_token: authSession.accessToken });
+    auth.setCredentials({ access_token: session.accessToken });
 
     // Initialize Google Sheets API
     const sheets = google.sheets({ version: 'v4', auth });
@@ -76,4 +72,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-} 
+}); 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -74,10 +74,13 @@ export function handleAPIError(error: unknown) {
 }
 
 export async function withErrorHandling<T>(
-  handler: () => Promise<T>
+  handler: () => Promise<T | NextResponse>
 ): Promise<NextResponse> {
   try {
     const result = await handler();
+    if (result instanceof NextResponse) {
+      return result;
+    }
     return apiJsonResponse(createAPIResponse(result));
   } catch (error) {
     return handleAPIError(error);


### PR DESCRIPTION
## Summary
- wrap routes with `withAuth`
- extend `withErrorHandling` to support streaming responses

## Testing
- `pnpm test` *(fails: vitest not found)*